### PR TITLE
Use variables to control enabling stackdriver monitoring / logging

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -40,11 +40,11 @@ resource "google_compute_instance_template" "bqmetricsd" {
     (module.container.vm_container_label_key) = module.container.vm_container_label
   }
 
-  metadata = {
-    (module.container.metadata_key) = module.container.metadata_value
-    google-logging-enabled          = "true"
-    google-monitoring-enabled       = "true"
-  }
+  metadata = merge(
+    { (module.container.metadata_key) = module.container.metadata_value },
+    var.stackdriver-monitoring ? { google-monitoring-enabled = "true" } : {},
+    var.stackdriver-logging ? { google-logging-enabled = "true" } : {},
+  )
 
   service_account {
     email  = local.service-account-email

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -57,21 +57,33 @@ variable "region" {
   default     = ""
 }
 
-variable "zone" {
-  type        = string
-  description = "The zone to run the bqmetrics service in"
-  default     = ""
-}
-
 variable "service-account-email" {
   type        = string
   description = "The service account email to run the bqmetrics service under"
   default     = ""
 }
 
+variable "stackdriver-logging" {
+  type        = bool
+  description = "Enables exporting of instance logs to Stackdriver (For bqmetrics service logs, etc.)"
+  default     = false
+}
+
+variable "stackdriver-monitoring" {
+  type        = bool
+  description = "Enables exporting of instance metrics to Stackdriver (For monitoring of RAM usage of bqmetrics service, etc.)"
+  default     = false
+}
+
 variable "subnetwork" {
   type        = string
   description = "The subnetwork to connect the bqmetrics instance to"
+}
+
+variable "zone" {
+  type        = string
+  description = "The zone to run the bqmetrics service in"
+  default     = ""
 }
 
 data "google_client_config" "current" {}


### PR DESCRIPTION
This PR makes the stackdriver monitoring and logging optional in the Terraform module, as when enabled together they generate a lot of cloudwatch logs which may not be desirable for users.