### PR TITLE
Fix whitespacing issue in terraform example

### DIFF
--- a/terraform/gcp/examples/custom-service-account/main.tf
+++ b/terraform/gcp/examples/custom-service-account/main.tf
@@ -29,7 +29,7 @@ resource "google_service_account" "custom" {
 # Give the service account permissions to get BigQuery table-level metrics
 resource "google_project_iam_member" "bigquery-access" {
   member = "serviceAccount:${google_service_account.custom.email}"
-  role    = "roles/bigquery.metadataViewer"
+  role   = "roles/bigquery.metadataViewer"
 }
 
 # Give the service account permissions to read the Datadog API key


### PR DESCRIPTION
This PR is the result of running `terraform fmt` on the example directories