### PR TITLE
Only grant log writer / metrics writer perms when needed

### DIFF
--- a/terraform/gcp/service-account.tf
+++ b/terraform/gcp/service-account.tf
@@ -16,7 +16,7 @@ resource "google_project_iam_member" "bq-role" {
 }
 
 resource "google_project_iam_member" "logger-role" {
-  count = local.create-service-account ? 1 : 0
+  count = local.create-service-account && var.stackdriver-logging ? 1 : 0
 
   member  = "serviceAccount:${google_service_account.bqmetricsd.0.email}"
   role    = "roles/logging.logWriter"
@@ -24,7 +24,7 @@ resource "google_project_iam_member" "logger-role" {
 }
 
 resource "google_project_iam_member" "metric-role" {
-  count = local.create-service-account ? 1 : 0
+  count = local.create-service-account && var.stackdriver-monitoring ? 1 : 0
 
   member  = "serviceAccount:${google_service_account.bqmetricsd.0.email}"
   role    = "roles/monitoring.metricWriter"


### PR DESCRIPTION
This PR updates the created service account roles to only include `roles/logging.logWriter` when stackdriver logging is enabled and only include `roles/monitoring.metricWriter` when stackdriver monitoring is enabled.