### PR TITLE
Update Terraform module to allow custom metrics creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,14 @@ line options.
 ### GCP Service Account permissions
 The service account running `bqmetricsd` may require the following roles:
 ```
+BigQuery Data Viewer
+    Required to generate custom metrics that need access to table data
+    This permission can be granted directly on the datasets in question 
 BigQuery Metadata Viewer
     Required to generate table level metrics
+BigQuery User
+    Required to generate custom metrics
 Secret Manager Secret Accessor
     Required to access the Datadog API key if stored in Secret Manager
+    This permission can be granted directly on the secret in question
 ```

--- a/terraform/gcp/examples/custom-metrics/README.md
+++ b/terraform/gcp/examples/custom-metrics/README.md
@@ -1,0 +1,4 @@
+# Custom metrics example
+
+This example shows how to use the Terraform module to export custom metrics
+into Datadog.

--- a/terraform/gcp/examples/custom-metrics/main.tf
+++ b/terraform/gcp/examples/custom-metrics/main.tf
@@ -1,0 +1,44 @@
+provider "google" {}
+
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    google = ">= 2.20.3"
+    random = "~> 2.2"
+  }
+}
+
+data "google_compute_subnetwork" "default" {
+  name   = "default"
+  region = "europe-west1"
+}
+
+module "bigquery-metrics-exporter" {
+  source = "../.."
+
+  datadog-api-key-secret = "datadog-api-key"
+  subnetwork             = data.google_compute_subnetwork.default.self_link
+  metric-tags            = ["env:nonprod", "team:my_team"]
+  custom-metrics = [
+    {
+      metric-name     = "cardinality"
+      metric-tags     = ["project_id:my_project", "dataset_id:my_dataset", "table_id:my_table"]
+      metric-interval = "5m"
+      sql             = <<-EOT
+        SELECT
+          APPROX_COUNT_DISTINCT(`column_1`) `column_1`,
+          APPROX_COUNT_DISTINCT(`column_2`) `column_2`,
+          APPROX_COUNT_DISTINCT(`column_3`) `column_3`
+        FROM
+          `my_project.my_dataset.my_table`
+      EOT
+    },
+    {
+      metric-name = "random"
+      sql         = <<-EOT
+        SELECT RAND() `random`
+      EOT
+    }
+  ]
+}

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -46,6 +46,8 @@ resource "google_compute_instance_template" "bqmetricsd" {
     var.stackdriver-logging ? { google-logging-enabled = "true" } : {},
   )
 
+  metadata_startup_script = data.template_file.startup.rendered
+
   service_account {
     email  = local.service-account-email
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -76,5 +78,25 @@ resource "google_compute_instance_group_manager" "bqmetricsd" {
   version {
     name              = "bqmetricsd"
     instance_template = google_compute_instance_template.bqmetricsd.id
+  }
+}
+
+locals {
+  config_init = {
+    custom-metrics            = var.custom-metrics
+    datadog-api-key-secret-id = data.google_secret_manager_secret_version.datadog-api-key.id
+    gcp-project-id            = local.bigquery-project
+    metric-interval           = var.metric-interval
+    metric-prefix             = var.metric-prefix
+    metric-tags               = var.metric-tags
+  }
+  config = { for k, v in local.config_init : k => v if v != "" }
+}
+
+data "template_file" "startup" {
+  template = file("${path.module}/templates/startup.sh")
+  vars = {
+    config_content = base64encode(jsonencode(local.config))
+    config_path    = local.config_path
   }
 }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -10,13 +10,21 @@ module "container" {
 
   container = {
     image = "${var.image-repository}:${var.image-tag}"
-    args = [
-      "--datadog-api-key-secret-id=${data.google_secret_manager_secret_version.datadog-api-key.id}",
-      "--gcp-project-id=${local.bigquery-project}",
-      "--metric-interval=${var.metric-interval}",
-      "--metric-tags=${local.metric-tags}",
-    ]
+    args  = ["--config-file=${local.config_path}"]
+    volumeMounts = [{
+      mountPath = local.config_path
+      name      = "config"
+      readOnly  = true
+    }]
   }
+
+  volumes = [{
+    name = "config"
+    hostPath = {
+      path = local.config_path
+    }
+  }]
+
   restart_policy = "Always"
 }
 

--- a/terraform/gcp/service-account.tf
+++ b/terraform/gcp/service-account.tf
@@ -39,3 +39,19 @@ resource "google_secret_manager_secret_iam_member" "secret-role" {
   secret_id = var.datadog-api-key-secret
   project   = local.project
 }
+
+resource "google_project_iam_member" "bq-data-reader-role" {
+  count = local.create-service-account && local.allow-bigquery-jobs ? 1 : 0
+
+  member  = "serviceAccount:${google_service_account.bqmetricsd.0.email}"
+  role    = "roles/bigquery.dataViewer"
+  project = local.project
+}
+
+resource "google_project_iam_member" "bq-user-role" {
+  count = local.create-service-account && local.allow-bigquery-jobs ? 1 : 0
+
+  member  = "serviceAccount:${google_service_account.bqmetricsd.0.email}"
+  role    = "roles/bigquery.jobUser"
+  project = local.project
+}

--- a/terraform/gcp/templates/startup.sh
+++ b/terraform/gcp/templates/startup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mkdir -p "$(dirname "${config_path}")"
+base64 -d > "${config_path}" <<< "${config_content}"

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -121,6 +121,7 @@ resource "random_shuffle" "zones" {
 }
 
 locals {
+  allow-bigquery-jobs    = length(var.custom-metrics) > 0
   bigquery-project       = coalesce(var.bigquery-project-id, local.project)
   config_path            = "/etc/bqmetrics/config.json"
   create-service-account = var.service-account-email == ""

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -4,6 +4,21 @@ variable "bigquery-project-id" {
   default     = ""
 }
 
+variable "custom-metrics" {
+  type        = any
+  description = <<-EOT
+  List of custom metric stanzas. Type is given as any as there are a number of optional components.
+  Expected type is below:
+  type = list(object({
+    metric-name     = string
+    metric-interval = optional(string)
+    metric-tags     = optional(list(string))
+    sql             = string
+  }))
+  EOT
+  default     = []
+}
+
 variable "datadog-api-key-secret" {
   type        = string
   description = "Name of the secret containing the Datadog API key stored in Google Secret Manager"
@@ -33,10 +48,16 @@ variable "metric-interval" {
   default     = "30s"
 }
 
+variable "metric-prefix" {
+  type        = string
+  description = "Optionally the prefix to give to metrics"
+  default     = ""
+}
+
 variable "metric-tags" {
-  type        = map(string)
+  type        = list(string)
   description = "The tags to attach on metrics"
-  default     = {}
+  default     = []
 }
 
 variable "network-tags" {
@@ -101,8 +122,8 @@ resource "random_shuffle" "zones" {
 
 locals {
   bigquery-project       = coalesce(var.bigquery-project-id, local.project)
+  config_path            = "/etc/bqmetrics/config.json"
   create-service-account = var.service-account-email == ""
-  metric-tags            = join(",", sort([for k, v in var.metric-tags : (v == "" ? k : "${k}:${v}")]))
   project                = coalesce(var.project, data.google_client_config.current.project)
   region                 = coalesce(var.region, data.google_client_config.current.region)
   service-account-email  = local.create-service-account ? google_service_account.bqmetricsd.0.email : var.service-account-email


### PR DESCRIPTION
This PR updates the Terraform module to allow users to specify custom metrics. Custom metrics require the use of a config file so I have refactored how all of the configuration is handled and moved it all into a config file. 

I have also included example usage of the module for creating custom metrics, which demonstrates the most basic custom metric and a slightly more complicated one that is expected to be representative of most common usage.

For completeness, this PR also adds a new optional variable for setting the value of the `metric-prefix` config parameter. The `metric-tags` variable is also changed from a `list(map)` type to a `list(string)` type to be consistent with the newly created custom metrics variable.