### PR TITLE
Add build target to the Makefile to build snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
       - image: circleci/golang:1.15
     steps:
       - checkout
+      - setup_remote_docker
       - run: make build
 
 workflows:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,14 +46,11 @@ changelog:
       - '^docs:'
       - '^test:'
 dockers:
-  - binaries:
-      - bqmetrics
-      - bqmetricsd
-    builds:
-      - bqmetrics
-      - bqmetricsd
+  - goarch: amd64
     goos: linux
-    goarch: amd64
+    ids:
+      - bqmetrics
+      - bqmetricsd
     image_templates:
       - "ovotech/{{ .ProjectName }}:latest"
       - "ovotech/{{ .ProjectName }}:{{ .Tag }}"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 MODULE := $(shell go list -m)
 PACKAGES := $(shell go list ./...)
 GOLINT := $(shell go list -f {{.Target}} golang.org/x/lint/golint)
+GORELEASER := $(shell brew --prefix goreleaser)/bin/goreleaser
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || git log -1 --pretty='%h')
 
 all: test
@@ -10,8 +11,14 @@ all: test
 ${GOLINT}:
 	go get -u golang.org/x/lint/golint
 
+${GORELEASER}:
+	brew install goreleaser/tap/goreleaser
+
 bin/%: cmd/% $(shell find pkg -name '*.go')
 	go build -ldflags "-X ${MODULE}/pkg/config.Version=${VERSION}" -o $@ ${MODULE}/$<
+
+build: ${GORELEASER}
+	${GORELEASER} release --rm-dist --snapshot
 
 clean:
 	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULE := $(shell go list -m)
 PACKAGES := $(shell go list ./...)
 GOLINT := $(shell go list -f {{.Target}} golang.org/x/lint/golint)
-GORELEASER := $(shell brew --prefix goreleaser)/bin/goreleaser
+GORELEASER := bin/goreleaser
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || git log -1 --pretty='%h')
 
 all: test
@@ -12,7 +12,7 @@ ${GOLINT}:
 	go get -u golang.org/x/lint/golint
 
 ${GORELEASER}:
-	brew install goreleaser/tap/goreleaser
+	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 
 bin/%: cmd/% $(shell find pkg -name '*.go')
 	go build -ldflags "-X ${MODULE}/pkg/config.Version=${VERSION}" -o $@ ${MODULE}/$<


### PR DESCRIPTION
This small PR adds a new target to the Makefile to create a build snapshot of the project, useful for testing features etc.