### PR TITLE
Fix racy test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,6 @@ lint: ${GOLINT}
 	${GOLINT} --set_exit_status ${PACKAGES}
 
 test:
-	go test ${PACKAGES}
+	go test --race ${PACKAGES}
 
 .PHONY: all build clean fmt lint push test

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -297,6 +297,8 @@ func TestConsumer_Run(t *testing.T) {
 
 	receiver <- &Metric{Metric: "row_count", Points: [][]float64{{1600, 1}}}
 
+	c.mx.Lock()
+	defer c.mx.Unlock()
 	if len(c.metrics) != 1 {
 		t.Errorf("len(c.metrics) = %v, want %v", len(c.metrics), 1)
 	}


### PR DESCRIPTION
This PR adds a lock to some data access during the `TestConsumer_Run` test