### PR TITLE
Fix dropped metric in bqmetrics

### DIFF
--- a/pkg/daemon/runner.go
+++ b/pkg/daemon/runner.go
@@ -103,16 +103,10 @@ func (d *Runner) RunUntil(ctx context.Context) error {
 
 	wg.Wait()
 
-	select {
-	case err := <-problem:
-		log.Err(err).Msg("Finishing Runner")
-
-		return err
-	default:
-		log.Info().Msg("Finishing Runner")
-
-		return nil
-	}
+	close(problem)
+	err := <- problem
+	log.Err(err).Msg("Finishing Runner")
+	return err
 }
 
 func (d *Runner) startMetricPublisher(ctx context.Context, abort context.CancelFunc, wg *sync.WaitGroup, problem chan error) {

--- a/pkg/daemon/runner.go
+++ b/pkg/daemon/runner.go
@@ -50,8 +50,11 @@ func NewRunner(ctx context.Context, cfg *config.Config) (*Runner, error) {
 func (d *Runner) RunOnce(ctx context.Context) error {
 	log.Info().Msg("Starting Runner")
 
-	receiver := d.consumer.Run()
-	defer close(receiver)
+	cwg := sync.WaitGroup{}
+	cwg.Add(1)
+
+	consumerCtx, done := context.WithCancel(ctx)
+	receiver := d.consumer.Run(consumerCtx, &cwg)
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(d.cfg.CustomMetrics))
@@ -64,6 +67,10 @@ func (d *Runner) RunOnce(ctx context.Context) error {
 	wg.Wait()
 
 	d.generator.ProduceMetrics(ctx, receiver)
+
+	done()
+	cwg.Wait()
+
 	err := d.consumer.PublishTo(ctx, d.publisher)
 
 	log.Err(err).Msg("Finishing Runner")
@@ -80,14 +87,13 @@ func (d *Runner) RunUntil(ctx context.Context) error {
 	var abort context.CancelFunc
 	ctx, abort = context.WithCancel(ctx)
 
-	receiver := d.consumer.Run()
-	defer close(receiver)
-
 	var problem chan error
 	problem = make(chan error, 1)
 
 	wg := sync.WaitGroup{}
-	wg.Add(2 + len(d.cfg.CustomMetrics))
+	wg.Add(3 + len(d.cfg.CustomMetrics))
+
+	receiver := d.consumer.Run(ctx, &wg)
 
 	go d.startMetricPublisher(ctx, abort, &wg, problem)
 	go d.startTableMetricsGenerator(ctx, &wg, receiver)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -185,11 +185,18 @@ func NewConsumer() *Consumer {
 }
 
 // Run will run the consumer, returning a channel to feed metrics into
-func (c *Consumer) Run() chan *Metric {
+func (c *Consumer) Run(ctx context.Context, wg *sync.WaitGroup) chan *Metric {
 	log.Debug().Msg("Starting metric consumer")
 
 	receiver := make(chan *Metric)
 	go func() {
+		<- ctx.Done()
+		close(receiver)
+	}()
+
+	go func() {
+		defer wg.Done()
+
 		for metric := range receiver {
 			c.consume(metric)
 		}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/ovotech/bigquery-metrics-extractor/pkg/config"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -289,7 +290,9 @@ func TestProducer_Produce(t *testing.T) {
 
 func TestConsumer_Run(t *testing.T) {
 	c := NewConsumer()
-	receiver := c.Run()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	receiver := c.Run(context.TODO(), &wg)
 
 	if len(c.metrics) != 0 {
 		t.Errorf("len(c.metrics) = %v, want %v", len(c.metrics), 0)


### PR DESCRIPTION
The daemon `RunOnce` method had a race condition where the consumer wasn't consuming the final metric before the publisher was submitting them. This fix makes the consumer take a `sync.WaitGroup` so that it can indicate when it has consumed all metrics, and a `context.Context` so that it can receive a `Done` signal to know when to finish consuming.