### PR TITLE
Add ability to filter datasets for producing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ line options.
 | DATADOG_API_KEY |  | The Datadog API key |
 | DATADOG_API_KEY_FILE | --datadog-api-key-file | File containing Datadog API key |
 | DATADOG_API_KEY_SECRET_ID | --datadog-api-key-secret-id | Path to a secret held in Google Secret Manager containing Datadog API key, e.g. `projects/my-project/secrets/datadog-api-key/versions/3` |
+| DATASET_FILTER | --dataset-filter | BigQuery label to filter datasets for metric collection |
 | GCP_PROJECT_ID | --gcp-project-id | (Required) The Google Cloud project containing the BigQuery tables to retrieve metrics from |
 | GOOGLE_APPLICATION_CREDENTIALS | | File containing service account details to authenticate to Google Cloud using |
 | LOG_LEVEL | | The logging level (e.g. trace, debug, info, warn, error). Defaults to *info* |

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -35,6 +35,14 @@
 #   - team:my-team
 
 ###
+# A label to filter BigQuery datasets by when querying for table metrics. Only
+# datasets that have this label will have metrics generated for them. For more
+# information see the BigQuery docs:
+# https://cloud.google.com/bigquery/docs/labels-intro
+#
+# dataset-filter: metrics-collector:bqmetrics
+
+###
 # An array of custom metrics to publish. Each custom metric has a name under
 # which it is published, as well as a list of tags (which are merged with the
 # global tags list) and collection interval.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ var Version = "0.0.0"
 // Config holds the configuration for the application
 type Config struct {
 	DatadogAPIKey  string         `viper:"datadog-api-key"`
+	DatasetFilter  string         `viper:"dataset-filter"`
 	GcpProject     string         `viper:"gcp-project-id"`
 	MetricPrefix   string         `viper:"metric-prefix"`
 	MetricTags     []string       `viper:"metric-tags"`
@@ -168,6 +169,7 @@ func configFlags(name string) *pflag.FlagSet {
 
 	flags := pflag.NewFlagSet(name, pflag.ExitOnError)
 	flags.String("config-file", "", "Path to the config file")
+	flags.String("dataset-filter", "", "BigQuery label to filter datasets for metric collection")
 	flags.String("datadog-api-key-file", "", "File containing the Datadog API key")
 	flags.String("datadog-api-key-secret-id", "", "Google Secret Manager Resource ID containing the Datadog API key")
 	flags.String("gcp-project-id", "", "The GCP project to extract BigQuery metrics from")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,16 +41,18 @@ func TestNewConfig(t *testing.T) {
 		want    *Config
 		wantErr bool
 	}{
-		{"all via env", setup([]string{"DATADOG_API_KEY=abc123", "GCP_PROJECT_ID=my-project-id", "METRIC_PREFIX=custom.gcp.bigquery.stats", "METRIC_TAGS=env:prod", "METRIC_INTERVAL=2m"}, nil, ""), args{"bqmetricstest"}, &Config{
+		{"all via env", setup([]string{"DATADOG_API_KEY=abc123", "DATASET_FILTER=bqmetrics:enabled", "GCP_PROJECT_ID=my-project-id", "METRIC_PREFIX=custom.gcp.bigquery.stats", "METRIC_TAGS=env:prod", "METRIC_INTERVAL=2m"}, nil, ""), args{"bqmetricstest"}, &Config{
 			DatadogAPIKey:  "abc123",
+			DatasetFilter:  "bqmetrics:enabled",
 			GcpProject:     "my-project-id",
 			MetricPrefix:   "custom.gcp.bigquery.stats",
 			MetricTags:     []string{"env:prod"},
 			MetricInterval: 2 * time.Minute,
 			Profiling:      false,
 		}, false},
-		{"all via cmd", setup(nil, []string{"--datadog-api-key-file=/tmp/dd.key", "--gcp-project-id=my-project-id", "--metric-prefix=custom.gcp.bigquery.stats", "--metric-tags=env:prod", "--metric-interval=2m", "--enable-profiler"}, "abc123"), args{"bqmetricstest"}, &Config{
+		{"all via cmd", setup(nil, []string{"--datadog-api-key-file=/tmp/dd.key", "--dataset-filter=bqmetrics:enabled", "--gcp-project-id=my-project-id", "--metric-prefix=custom.gcp.bigquery.stats", "--metric-tags=env:prod", "--metric-interval=2m", "--enable-profiler"}, "abc123"), args{"bqmetricstest"}, &Config{
 			DatadogAPIKey:  "abc123",
+			DatasetFilter:  "bqmetrics:enabled",
 			GcpProject:     "my-project-id",
 			MetricPrefix:   "custom.gcp.bigquery.stats",
 			MetricTags:     []string{"env:prod"},
@@ -111,7 +113,7 @@ func TestNewConfig_configFile(t *testing.T) {
 		_ = os.Remove(n)
 	}()
 
-	data := []byte("{\"datadog-api-key\": \"abc123\", \"gcp-project-id\": \"my-project-id\", \"metric-prefix\": \"custom.gcp.bigquery.stats\", \"metric-tags\": \"env:prod,team:my-team\", \"metric-interval\": \"2m\"}")
+	data := []byte("{\"datadog-api-key\": \"abc123\", \"dataset-filter\": \"bqmetrics:enabled\", \"gcp-project-id\": \"my-project-id\", \"metric-prefix\": \"custom.gcp.bigquery.stats\", \"metric-tags\": \"env:prod,team:my-team\", \"metric-interval\": \"2m\"}")
 	if _, err = f.Write(data); err != nil {
 		t.Fatalf("error when writing test config file: %s", err)
 	}
@@ -119,6 +121,7 @@ func TestNewConfig_configFile(t *testing.T) {
 	os.Args = []string{"./bqmetricstest", "--config-file", f.Name()}
 	want := &Config{
 		DatadogAPIKey:  "abc123",
+		DatasetFilter:  "bqmetrics:enabled",
 		GcpProject:     "my-project-id",
 		MetricPrefix:   "custom.gcp.bigquery.stats",
 		MetricTags:     []string{"env:prod", "team:my-team"},

--- a/pkg/sources/bigquery.go
+++ b/pkg/sources/bigquery.go
@@ -36,7 +36,7 @@ func NewGenerator(ctx context.Context, cfg *config.Config) (*Generator, error) {
 
 // ProduceMetrics will generate table level metrics for all BigQuery tables
 func (g Generator) ProduceMetrics(ctx context.Context, receiver chan *metrics.Metric) {
-	log.Debug().Msg("Producing table level metrics")
+	log.Debug().Str("dataset-filter", g.cfg.DatasetFilter).Msg("Producing table level metrics")
 
 	wg := sync.WaitGroup{}
 	for ds := range iterateDatasets(ctx, g.client, g.cfg.DatasetFilter) {

--- a/pkg/sources/bigquery.go
+++ b/pkg/sources/bigquery.go
@@ -158,7 +158,9 @@ func iterateDatasets(ctx context.Context, client bq.Client, filter string) chan 
 	go func() {
 		defer close(out)
 		iter := client.Datasets(ctx)
-		iter.SetFilter(filter)
+		if filter != "" {
+			iter.SetFilter(fmt.Sprintf("labels.%s", filter))
+		}
 
 		for {
 			ds, err := iter.Next()

--- a/pkg/sources/bigquery_test.go
+++ b/pkg/sources/bigquery_test.go
@@ -51,6 +51,18 @@ func Test_iterateDatasets(t *testing.T) {
 	}
 }
 
+func Test_iterateDatasets_withFiltering(t *testing.T) {
+	cl := newMockClient("my-project", []mockDataset{})
+	out := iterateDatasets(context.TODO(), cl, "filter:yes")
+	<- out
+
+	want := "labels.filter:yes"
+	got := cl.iterator.(*mockDatasetIterator).filter
+	if want != got {
+		t.Errorf("iterateDatasets() applied filter got %v, want %v", got, want)
+	}
+}
+
 func TestGenerator_outputTableLevelMetrics(t *testing.T) {
 	type args struct {
 		t bq.Table
@@ -97,7 +109,7 @@ func TestGenerator_outputTableLevelMetrics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := Generator{
 				cfg:      &config.Config{},
-				client:   mockClient{},
+				client:   &mockClient{},
 				producer: metrics.NewProducer(&config.Config{}),
 			}
 
@@ -158,7 +170,7 @@ func compareMetrics(got, want *metrics.Metric) bool {
 func TestGenerator_runSQLQuery(t *testing.T) {
 	g := Generator{
 		cfg:      &config.Config{},
-		client:   mockClient{},
+		client:   &mockClient{},
 		producer: metrics.NewProducer(&config.Config{}),
 	}
 
@@ -177,7 +189,7 @@ func TestGenerator_runSQLQuery(t *testing.T) {
 func TestGenerator_produceCustomMetrics(t *testing.T) {
 	g := Generator{
 		cfg: &config.Config{},
-		client: mockClient{
+		client: &mockClient{
 			query: &mockQuery{
 				job: &mockJob{
 					rows: &mockRowIterator{
@@ -216,7 +228,7 @@ func TestGenerator_produceCustomMetrics(t *testing.T) {
 func TestGenerator_produceCustomMetrics_noMetricsWhenNoResults(t *testing.T) {
 	g := Generator{
 		cfg:      &config.Config{},
-		client:   mockClient{},
+		client:   &mockClient{},
 		producer: metrics.NewProducer(&config.Config{}),
 	}
 
@@ -245,7 +257,7 @@ func TestGenerator_produceCustomMetrics_noMetricsWhenNoResults(t *testing.T) {
 func TestGenerator_produceCustomMetrics_produceMetricsWhenZeroResult(t *testing.T) {
 	g := Generator{
 		cfg: &config.Config{},
-		client: mockClient{
+		client: &mockClient{
 			query: &mockQuery{
 				job: &mockJob{
 					rows: &mockRowIterator{
@@ -286,17 +298,23 @@ type mockClient struct {
 	proj     string
 	datasets []mockDataset
 	query    *mockQuery
+	iterator bq.DatasetIterator
 }
 
-func (m mockClient) Datasets(_ context.Context) bq.DatasetIterator {
-	return &mockDatasetIterator{
+func (m *mockClient) Datasets(_ context.Context) bq.DatasetIterator {
+	if m.iterator != nil {
+		return m.iterator
+	}
+
+	m.iterator = &mockDatasetIterator{
 		filter:   "",
 		datasets: m.datasets,
 		idx:      0,
 	}
+	return m.iterator
 }
 
-func (m mockClient) Query(sql string) bq.Query {
+func (m *mockClient) Query(sql string) bq.Query {
 	if m.query != nil {
 		return m.query
 	}
@@ -308,11 +326,11 @@ func (m mockClient) Query(sql string) bq.Query {
 	}
 }
 
-func newMockClient(proj string, datasets []mockDataset) mockClient {
+func newMockClient(proj string, datasets []mockDataset) *mockClient {
 	for i := range datasets {
 		datasets[i].proj = proj
 	}
-	return mockClient{
+	return &mockClient{
 		proj:     proj,
 		datasets: datasets,
 	}

--- a/pkg/sources/bigquery_test.go
+++ b/pkg/sources/bigquery_test.go
@@ -38,7 +38,7 @@ func Test_iterateDatasets(t *testing.T) {
 		newMockDatasetDefaults("dataset-1"),
 		newMockDatasetDefaults("dataset-2"),
 	})
-	out := iterateDatasets(context.TODO(), cl)
+	out := iterateDatasets(context.TODO(), cl, "")
 
 	got := make([]string, 0)
 	for ds := range out {


### PR DESCRIPTION
This PR adds a new configuration option so that only tables in certain datasets can have metrics produced for them. It makes use of the BigQuery labelling feature in order to filter.