### PR TITLE
Add a health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ line options.
 | DATASET_FILTER | --dataset-filter | BigQuery label to filter datasets for metric collection |
 | GCP_PROJECT_ID | --gcp-project-id | (Required) The Google Cloud project containing the BigQuery tables to retrieve metrics from |
 | GOOGLE_APPLICATION_CREDENTIALS | | File containing service account details to authenticate to Google Cloud using |
+| HEALTHCHECK_ENABLED | --healthcheck.enabled | Whether to enable the health check endpoint at /health. Defaults to *false* |
+| HEALTHCHECK_PORT | --healthcheck.port | The port to run the health check server on. Defaults to *8080* | 
 | LOG_LEVEL | | The logging level (e.g. trace, debug, info, warn, error). Defaults to *info* |
 | METRIC_INTERVAL | --metric-interval | The interval between metric collection rounds. Must contain a unit and valid units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Defaults to *30s* |
 | METRIC_PREFIX | --metric-prefix | The prefix for the metric names exported to Datadog. Defaults to *custom.gcp.bigquery* |

--- a/cmd/bqmetricsd/main.go
+++ b/cmd/bqmetricsd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/ovotech/bigquery-metrics-extractor/pkg/config"
 	"github.com/ovotech/bigquery-metrics-extractor/pkg/daemon"
+	"github.com/ovotech/bigquery-metrics-extractor/pkg/health"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"net/http"
@@ -35,6 +36,20 @@ func main() {
 
 		go func() {
 			log.Err(http.ListenAndServe(addr, mux)).Msg("Shutting down profiler")
+		}()
+	}
+
+	if cfg.HealthCheck.Enabled {
+		addr := fmt.Sprintf("localhost:%d", cfg.HealthCheck.Port)
+		log.Info().Msgf("Running healthcheck server on %s", addr)
+
+		healthsrv := health.ServiceStatus{Status: health.Ok}
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/health", healthsrv.Handler)
+
+		go func() {
+			log.Err(http.ListenAndServe(addr, mux)).Msg("Shutting down healthcheck server")
 		}()
 	}
 

--- a/cmd/bqmetricsd/main.go
+++ b/cmd/bqmetricsd/main.go
@@ -22,8 +22,8 @@ func main() {
 		log.Fatal().Err(err).Msg("Failed to parse config")
 	}
 
-	if cfg.Profiling {
-		addr := "localhost:6060"
+	if cfg.Profiler.Enabled {
+		addr := fmt.Sprintf("localhost:%d", cfg.Profiler.Port)
 		log.Info().Msgf("Running profiler on %s", addr)
 
 		go func() {

--- a/cmd/bqmetricsd/main.go
+++ b/cmd/bqmetricsd/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"net/http"
-	_ "net/http/pprof"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 )
@@ -26,8 +26,15 @@ func main() {
 		addr := fmt.Sprintf("localhost:%d", cfg.Profiler.Port)
 		log.Info().Msgf("Running profiler on %s", addr)
 
+		mux := http.NewServeMux()
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
 		go func() {
-			log.Err(http.ListenAndServe(addr, nil)).Msg("Shutting down profiler")
+			log.Err(http.ListenAndServe(addr, mux)).Msg("Shutting down profiler")
 		}()
 	}
 

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -57,3 +57,11 @@
 #       SELECT APPROX_COUNT_DISTINCT(`my-column-1`) AS `my-column-1`,
 #              APPROX_COUNT_DISTINCT(`my-column-2`) AS `my-column-2`
 #       FROM `my-project.my-dataset.my-table`
+
+###
+# Configuration for the healthcheck endpoint, used to determine whether the
+# service is healthy or not
+#
+# healthcheck:
+#   enabled: true
+#   port: 8080

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	MetricInterval time.Duration  `viper:"metric-interval"`
 	CustomMetrics  []CustomMetric `viper:"custom-metrics"`
 	Profiler       Profiler       `viper:"profiler"`
+	HealthCheck    HealthCheck    `viper:"healthcheck"`
 }
 
 // CustomMetric holds details about a metric generated from an SQL query
@@ -57,6 +58,12 @@ type CustomMetric struct {
 
 // Profiler holds configuration details for the profiler
 type Profiler struct {
+	Enabled bool `viper:"enabled"`
+	Port    int  `viper:"port"`
+}
+
+// HealthCheck holds configuration details for the health endpoint
+type HealthCheck struct {
 	Enabled bool `viper:"enabled"`
 	Port    int  `viper:"port"`
 }
@@ -156,6 +163,12 @@ func ValidateConfig(c *Config) error {
 		}
 	}
 
+	if c.HealthCheck.Enabled {
+		if c.HealthCheck.Port <= 0 || c.HealthCheck.Port > 65535 {
+			return ErrInvalidPort
+		}
+	}
+
 	if c.Profiler.Enabled {
 		if c.Profiler.Port <= 0 || c.Profiler.Port > 65535 {
 			return ErrInvalidPort
@@ -190,6 +203,8 @@ func configFlags(name string) *pflag.FlagSet {
 	flags.StringSlice("metric-tags", []string{}, "Comma-delimited list of tags to attach to metrics")
 	flags.Bool("profiler.enabled", false, "Enables the profiler")
 	flags.Int("profiler.port", 6060, "The port on which to run the profiler server")
+	flags.Bool("healthcheck.enabled", false, "Enables the health check endpoint")
+	flags.Int("healthcheck.port", 8080, "The port on which to run the server providing the health check endpoint")
 
 	_ = flags.Parse(os.Args[1:])
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,16 +48,16 @@ func TestNewConfig(t *testing.T) {
 			MetricPrefix:   "custom.gcp.bigquery.stats",
 			MetricTags:     []string{"env:prod"},
 			MetricInterval: 2 * time.Minute,
-			Profiling:      false,
+			Profiler:       Profiler{false, 6060},
 		}, false},
-		{"all via cmd", setup(nil, []string{"--datadog-api-key-file=/tmp/dd.key", "--dataset-filter=bqmetrics:enabled", "--gcp-project-id=my-project-id", "--metric-prefix=custom.gcp.bigquery.stats", "--metric-tags=env:prod", "--metric-interval=2m", "--enable-profiler"}, "abc123"), args{"bqmetricstest"}, &Config{
+		{"all via cmd", setup(nil, []string{"--datadog-api-key-file=/tmp/dd.key", "--dataset-filter=bqmetrics:enabled", "--gcp-project-id=my-project-id", "--metric-prefix=custom.gcp.bigquery.stats", "--metric-tags=env:prod", "--metric-interval=2m", "--profiler.enabled"}, "abc123"), args{"bqmetricstest"}, &Config{
 			DatadogAPIKey:  "abc123",
 			DatasetFilter:  "bqmetrics:enabled",
 			GcpProject:     "my-project-id",
 			MetricPrefix:   "custom.gcp.bigquery.stats",
 			MetricTags:     []string{"env:prod"},
 			MetricInterval: 2 * time.Minute,
-			Profiling:      true,
+			Profiler:       Profiler{true, 6060},
 		}, false},
 		{"mixture of sources", setup([]string{"DATADOG_API_KEY=abc123", "GCP_PROJECT_ID=my-project-id"}, []string{"--metric-prefix=custom.gcp.bigquery.stats", "--metric-tags=env:prod", "--metric-interval=2m"}, ""), args{"bqmetricstest"}, &Config{
 			DatadogAPIKey:  "abc123",
@@ -65,7 +65,7 @@ func TestNewConfig(t *testing.T) {
 			MetricPrefix:   "custom.gcp.bigquery.stats",
 			MetricTags:     []string{"env:prod"},
 			MetricInterval: 2 * time.Minute,
-			Profiling:      false,
+			Profiler:       Profiler{false, 6060},
 		}, false},
 		{"minimum required config", setup([]string{"DATADOG_API_KEY=abc123", "GCP_PROJECT_ID=my-project-id"}, nil, ""), args{"bqmetricstest"}, &Config{
 			DatadogAPIKey:  "abc123",
@@ -73,7 +73,7 @@ func TestNewConfig(t *testing.T) {
 			MetricPrefix:   DefaultMetricPrefix,
 			MetricTags:     nil,
 			MetricInterval: 30 * time.Second,
-			Profiling:      false,
+			Profiler:       Profiler{false, 6060},
 		}, false},
 		{"default credentials", setup([]string{"DATADOG_API_KEY=abc123", "GOOGLE_APPLICATION_CREDENTIALS=/tmp/dd.key"}, nil, "{\"type\": \"service_account\", \"project_id\": \"my-project-id\"}"), args{"bqmetricstest"}, &Config{
 			DatadogAPIKey:  "abc123",
@@ -81,7 +81,7 @@ func TestNewConfig(t *testing.T) {
 			MetricPrefix:   DefaultMetricPrefix,
 			MetricTags:     nil,
 			MetricInterval: 30 * time.Second,
-			Profiling:      false,
+			Profiler:       Profiler{false, 6060},
 		}, false},
 		{"unreadable key file", setup([]string{"DATADOG_API_KEY_FILE=/tmp/not-found.key", "GCP_PROJECT_ID=my-project-id"}, nil, "abc123"), args{"bqmetricstest"}, nil, true},
 		{"missing key", setup([]string{"GCP_PROJECT_ID=my-project-id"}, nil, ""), args{"bqmetricstest"}, nil, true},
@@ -126,7 +126,7 @@ func TestNewConfig_configFile(t *testing.T) {
 		MetricPrefix:   "custom.gcp.bigquery.stats",
 		MetricTags:     []string{"env:prod", "team:my-team"},
 		MetricInterval: 2 * time.Minute,
-		Profiling:      false,
+		Profiler:       Profiler{false, 6060},
 	}
 
 	got, err := NewConfig("bqmetricstest")
@@ -186,7 +186,7 @@ func TestNewConfig_configFileWithCustomQueries(t *testing.T) {
 		MetricPrefix:   "custom.gcp.bigquery.stats",
 		MetricTags:     []string{"env:prod", "team:my-team"},
 		MetricInterval: 2 * time.Minute,
-		Profiling:      false,
+		Profiler:       Profiler{false, 6060},
 		CustomMetrics: []CustomMetric{{
 			MetricName:     "my_metric",
 			MetricTags:     []string{"table_id:table"},
@@ -262,7 +262,7 @@ func TestValidateConfig(t *testing.T) {
 			MetricPrefix:   "custom.gcp.bigquery.stats",
 			MetricTags:     []string{"env:prod"},
 			MetricInterval: time.Duration(30000),
-			Profiling:      false,
+			Profiler:       Profiler{false, 6060},
 		}}, false},
 		{"custom metrics okay", args{&Config{
 			DatadogAPIKey:  "abc123",

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -20,4 +20,7 @@ var (
 
 	// ErrMissingCustomMetricSQL is the error returned when a CustomMetric is missing SQL
 	ErrMissingCustomMetricSQL = errors.New("no custom metric sql query configured")
+
+	// ErrInvalidPort is the error returned when an invalid port is specified
+	ErrInvalidPort = errors.New("invalid port specified")
 )

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -6,10 +6,14 @@ import (
 	"net/http"
 )
 
+// Status is the health status of the service
 type Status string
 
 const (
-	Ok = Status("OK")
+	// Ok status means that the service is operating nominally
+	Ok    = Status("OK")
+
+	// Error status means that something is going wrong with the service
 	Error = Status("Error")
 )
 

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -1,0 +1,40 @@
+package health
+
+import (
+	"encoding/json"
+	"github.com/rs/zerolog/log"
+	"net/http"
+)
+
+type Status string
+
+const (
+	Ok = Status("OK")
+	Error = Status("Error")
+)
+
+// ServiceStatus holds information about the health of the bqmetricsd service
+type ServiceStatus struct {
+	Status Status `json:"status"`
+}
+
+// Handler will handle HTTP requests to the health endpoint
+func (hs ServiceStatus) Handler(w http.ResponseWriter, _ *http.Request) {
+	data, err := json.Marshal(hs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	switch hs.Status {
+	case Ok:
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	if _, err = w.Write(data); err != nil {
+		log.Err(err).Msg("error when writing health http response")
+	}
+}

--- a/pkg/health/http_test.go
+++ b/pkg/health/http_test.go
@@ -12,15 +12,15 @@ func TestServiceStatus_Handler(t *testing.T) {
 	}
 	type want struct {
 		status int
-		body string
+		body   string
 	}
 	tests := []struct {
 		name   string
 		fields fields
 		want   want
 	}{
-		{ "health ok", fields{Status: Ok}, want{200, "{\"status\":\"OK\"}"}},
-		{ "health fail", fields{Status: Error}, want{500, "{\"status\":\"Error\"}"}},
+		{"health ok", fields{Status: Ok}, want{200, "{\"status\":\"OK\"}"}},
+		{"health fail", fields{Status: Error}, want{500, "{\"status\":\"Error\"}"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/health/http_test.go
+++ b/pkg/health/http_test.go
@@ -1,0 +1,52 @@
+package health
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServiceStatus_Handler(t *testing.T) {
+	type fields struct {
+		Status Status
+	}
+	type want struct {
+		status int
+		body string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{ "health ok", fields{Status: Ok}, want{200, "{\"status\":\"OK\"}"}},
+		{ "health fail", fields{Status: Error}, want{500, "{\"status\":\"Error\"}"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hs := ServiceStatus{
+				Status: tt.fields.Status,
+			}
+
+			req, err := http.NewRequest("GET", "/health", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(hs.Handler)
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.want.status {
+				t.Errorf("handler returned wrong status code: got %v want %v",
+					rr.Code, tt.want.status)
+			}
+
+			if rr.Body.String() != tt.want.body {
+				t.Errorf("handler returned unexpected body: got %v want %v",
+					rr.Body.String(), tt.want.body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds an optional health check endpoint to the `bqmetricsd` service. The health check endpoint currently returns a 200 OK response to every request, but it might be beneficial in the future to expand the health check to, for example, ensure that metrics are being generated or submitted correctly.